### PR TITLE
added SpaceMouse Compact (wired) to device dictionary

### DIFF
--- a/ToolShelf-4-3Dconnexion/ConnexionClientHelper.swift
+++ b/ToolShelf-4-3Dconnexion/ConnexionClientHelper.swift
@@ -45,6 +45,7 @@ class ConnexionClientHelper {
 		50735: "SpceMouse (wireless)",
 		50737: "SpceMouse Pro (cabled)",
 		50738: "SpceMouse Pro (wireless)",
+		50741: "SpaceMouse Compact (wired)",
 		50768: "CADMouse (wired)"]
 	
 	// ==============================================================================


### PR DESCRIPTION
Looks like the SpaceMouse Compact (wired) has an ID that wasn't in the device dictionary. This adds it.